### PR TITLE
style: refresh desktop navigation styling

### DIFF
--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
@@ -160,69 +160,78 @@
     }
 }
 
-@media (min-width: 769px) {
+@media (min-width: 768px) {
     .nav-drawer__header {
         flex-direction: column;
         align-items: flex-start;
         justify-content: flex-start;
-        gap: clamp(1rem, 2vw, 1.5rem);
-        padding: clamp(1.75rem, 3vw, 2.25rem);
-        margin-bottom: clamp(1.5rem, 3vw, 2.25rem);
+        gap: clamp(1.35rem, 2.4vw, 1.85rem);
+        padding: clamp(1.85rem, 3vw, 2.4rem);
+        margin-bottom: clamp(1.6rem, 3vw, 2.4rem);
         border-radius: 1.65rem;
-        border: 1px solid color-mix(in srgb, var(--primary-color) 22%, transparent);
+        border: 1px solid color-mix(in srgb, var(--primary-color) 16%, transparent);
         background:
-            radial-gradient(120% 120% at 110% -20%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 65%),
-            linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 48%, transparent) 0%, color-mix(in srgb, #5b5af7 68%, transparent) 100%);
-        box-shadow: 0 24px 48px rgba(33, 83, 200, 0.24);
+            radial-gradient(120% 140% at 0% 0%, color-mix(in srgb, var(--primary-color) 22%, transparent) 0%, transparent 65%),
+            linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(243, 247, 255, 0.92));
+        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
         border-bottom: none;
         position: relative;
         overflow: hidden;
-        backdrop-filter: blur(18px);
-        -webkit-backdrop-filter: blur(18px);
+    }
+
+    .nav-drawer__header::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(120% 120% at 100% 0%, color-mix(in srgb, var(--primary-color) 26%, transparent) 0%, transparent 72%);
+        opacity: 0.65;
+        pointer-events: none;
     }
 
     .nav-drawer__header::after {
         content: "";
         position: absolute;
         inset: 0.6rem;
-        border-radius: 1.35rem;
-        border: 1px solid rgba(255, 255, 255, 0.22);
+        border-radius: 1.25rem;
+        border: 1px solid rgba(255, 255, 255, 0.35);
         pointer-events: none;
+        z-index: 0;
     }
 
     .nav-drawer__brand {
         align-items: flex-start;
-        gap: clamp(0.85rem, 1.8vw, 1.25rem);
+        gap: clamp(0.85rem, 2vw, 1.25rem);
         position: relative;
         z-index: 1;
     }
 
     .nav-drawer__logo {
-        width: clamp(3.25rem, 4vw, 3.75rem);
-        height: clamp(3.25rem, 4vw, 3.75rem);
-        border-radius: 1.25rem;
+        width: clamp(3.1rem, 4vw, 3.6rem);
+        height: clamp(3.1rem, 4vw, 3.6rem);
+        border-radius: 1.2rem;
         display: grid;
         place-items: center;
-        background: rgba(255, 255, 255, 0.22);
-        border: 1px solid rgba(255, 255, 255, 0.4);
-        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+        background:
+            linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 82%, #7b66ff 18%), color-mix(in srgb, var(--primary-color) 52%, #60a5fa 48%));
+        box-shadow: 0 22px 44px color-mix(in srgb, var(--primary-color) 28%, transparent);
         color: #ffffff;
-        font-size: clamp(1.2rem, 2vw, 1.35rem);
+        font-size: clamp(1.25rem, 2vw, 1.45rem);
+        border: 1px solid rgba(255, 255, 255, 0.38);
     }
 
     .nav-drawer__title {
-        color: #ffffff;
-        font-size: clamp(1.35rem, 2.4vw, 1.6rem);
+        color: color-mix(in srgb, var(--primary-color) 48%, #0f172a 52%);
+        font-size: clamp(1.35rem, 2.3vw, 1.65rem);
         font-weight: 700;
-        letter-spacing: -0.025em;
+        letter-spacing: -0.02em;
     }
 
     .nav-drawer__subtitle {
-        color: rgba(255, 255, 255, 0.85);
+        color: color-mix(in srgb, var(--primary-color) 24%, var(--text-secondary) 76%);
         font-size: clamp(0.9rem, 1.6vw, 1rem);
         font-weight: 500;
-        max-width: 24ch;
-        line-height: 1.4;
+        max-width: 26ch;
+        line-height: 1.45;
     }
 
     .nav-drawer__close {
@@ -230,6 +239,42 @@
     }
 
     .nav-drawer__content {
-        gap: clamp(1.25rem, 2.5vw, 1.75rem);
+        gap: clamp(1.35rem, 2.5vw, 1.85rem);
+        padding: 0 0.25rem 0.75rem;
+    }
+
+    .nav-drawer__footer {
+        padding-top: clamp(1.35rem, 2.8vw, 2rem);
+    }
+
+    .nav-drawer__divider {
+        background: color-mix(in srgb, var(--primary-color) 16%, transparent);
+        opacity: 0.55;
+    }
+
+    .nav-drawer__logout {
+        padding: clamp(0.75rem, 1.8vw, 0.95rem) clamp(0.9rem, 2vw, 1.25rem);
+        border-radius: 1.1rem;
+        border: 1px solid color-mix(in srgb, var(--primary-color) 14%, transparent);
+        background: rgba(255, 255, 255, 0.86);
+        color: color-mix(in srgb, var(--text-secondary) 70%, var(--primary-color) 30%);
+        font-weight: 600;
+        box-shadow: 0 18px 32px rgba(15, 23, 42, 0.08);
+    }
+
+    .nav-drawer__logout:hover {
+        background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 38%, transparent), color-mix(in srgb, var(--primary-color) 18%, transparent));
+        color: #ffffff;
+        box-shadow: 0 24px 42px color-mix(in srgb, var(--primary-color) 24%, transparent);
+    }
+
+    .nav-drawer__logout:focus-visible {
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-color) 32%, transparent);
+        background: rgba(255, 255, 255, 0.92);
+        color: color-mix(in srgb, var(--primary-color) 45%, var(--text-primary) 55%);
+    }
+
+    .nav-drawer__logout:active {
+        background: color-mix(in srgb, var(--primary-color) 18%, white);
     }
 }

--- a/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
@@ -665,7 +665,7 @@ a:hover, .btn-link:hover {
 }
 
 /* Desktop & tablet navigation layout */
-@media (min-width: 769px) {
+@media (min-width: 768px) {
     .page {
         --sidebar-width: clamp(260px, 24vw, 320px);
     }
@@ -693,14 +693,14 @@ a:hover, .btn-link:hover {
         max-width: var(--sidebar-width);
         height: calc(100vh - (var(--desktop-shell-padding) * 2));
         max-height: calc(100vh - (var(--desktop-shell-padding) * 2));
-        border-radius: 1.75rem;
-        border: 1px solid color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 18%, transparent);
+        border-radius: 1.85rem;
+        border: 1px solid color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 15%, transparent);
         background:
-            radial-gradient(140% 120% at 100% 0%, color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 18%, transparent) 0%, transparent 55%),
-            var(--surface-gradient, var(--surface-color));
-        box-shadow: 0 32px 64px rgba(15, 23, 42, 0.14);
-        backdrop-filter: blur(20px);
-        -webkit-backdrop-filter: blur(20px);
+            radial-gradient(140% 120% at 85% 0%, color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 18%, transparent) 0%, transparent 62%),
+            linear-gradient(180deg, rgba(246, 248, 255, 0.96), rgba(241, 244, 255, 0.92));
+        box-shadow: 0 28px 54px rgba(15, 23, 42, 0.12);
+        backdrop-filter: blur(22px);
+        -webkit-backdrop-filter: blur(22px);
         padding: 0;
         overflow: hidden;
     }
@@ -711,13 +711,199 @@ a:hover, .btn-link:hover {
 
     .desktop-layout .nav-drawer {
         height: 100%;
-        padding: clamp(1.75rem, 4vw, 2.5rem) clamp(1.5rem, 3vw, 2.5rem);
-        gap: clamp(1.5rem, 3vw, 2rem);
+        padding: clamp(1.9rem, 4vw, 2.6rem) clamp(1.7rem, 3vw, 2.8rem);
+        gap: clamp(1.6rem, 3vw, 2.1rem);
     }
 
     .desktop-layout .nav-scroll-container {
-        margin-right: -0.5rem;
-        padding-right: 0.75rem;
+        margin-right: -0.35rem;
+        padding-right: 1rem;
+        padding-bottom: 0.35rem;
+        scrollbar-color: color-mix(in srgb, var(--primary-color) 24%, transparent) transparent;
+    }
+
+    .desktop-layout .nav-scroll-container::-webkit-scrollbar-thumb {
+        background-color: color-mix(in srgb, var(--primary-color) 24%, transparent);
+    }
+
+    .desktop-layout .nav-item {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .desktop-layout .nav-item + .nav-item {
+        margin-top: 0.25rem;
+    }
+
+    .desktop-layout .nav-section-header {
+        padding: 0.95rem 1.25rem;
+        margin: 0.45rem 0;
+        border-radius: 1.15rem;
+        background: rgba(255, 255, 255, 0.85);
+        border: 1px solid color-mix(in srgb, var(--primary-color) 12%, transparent);
+        box-shadow: 0 18px 34px rgba(15, 23, 42, 0.08);
+        color: color-mix(in srgb, var(--text-secondary) 65%, var(--primary-color) 35%);
+        font-size: 0.95rem;
+    }
+
+    .desktop-layout .nav-section-header:hover {
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(240, 244, 255, 0.94));
+        color: color-mix(in srgb, var(--primary-color) 70%, #1f2238 30%);
+        box-shadow: 0 24px 40px rgba(15, 23, 42, 0.12);
+        transform: translateX(6px);
+    }
+
+    .desktop-layout .nav-section-header i {
+        width: 2.4rem;
+        height: 2.4rem;
+        border-radius: 0.9rem;
+        display: grid;
+        place-items: center;
+        font-size: 1.05rem;
+        background: color-mix(in srgb, var(--primary-color) 12%, transparent);
+        color: color-mix(in srgb, var(--primary-color) 72%, #243b5d 28%);
+        box-shadow: none;
+    }
+
+    .desktop-layout .nav-section-header:hover i {
+        background: color-mix(in srgb, var(--primary-color) 28%, white 72%);
+        color: color-mix(in srgb, var(--primary-color) 90%, white 10%);
+        box-shadow: 0 12px 26px color-mix(in srgb, var(--primary-color) 24%, transparent);
+    }
+
+    .desktop-layout .nav-section-header .submenu-toggle {
+        color: color-mix(in srgb, var(--primary-color) 30%, var(--text-secondary) 70%);
+    }
+
+    .desktop-layout .nav-section-header:hover .submenu-toggle {
+        color: color-mix(in srgb, var(--primary-color) 65%, white 35%);
+    }
+
+    .desktop-layout .sidebar .nav-link {
+        padding: 1rem 1.2rem;
+        border-radius: 1.15rem;
+        border: 1px solid color-mix(in srgb, var(--primary-color) 12%, transparent);
+        background: rgba(255, 255, 255, 0.9);
+        color: color-mix(in srgb, var(--text-secondary) 70%, var(--primary-color) 30%) !important;
+        box-shadow: 0 16px 34px rgba(15, 23, 42, 0.08);
+        backdrop-filter: blur(6px);
+    }
+
+    .desktop-layout .sidebar .nav-link i {
+        width: 2.4rem;
+        height: 2.4rem;
+        border-radius: 0.9rem;
+        display: grid;
+        place-items: center;
+        font-size: 1.05rem;
+        background: color-mix(in srgb, var(--primary-color) 14%, transparent);
+        color: color-mix(in srgb, var(--primary-color) 80%, #243b5d 20%);
+        box-shadow: none;
+    }
+
+    .desktop-layout .sidebar .nav-link:hover {
+        transform: translateX(8px);
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(241, 244, 255, 0.96));
+        border-color: color-mix(in srgb, var(--primary-color) 28%, transparent);
+        color: color-mix(in srgb, var(--primary-color) 65%, #1f2937 35%) !important;
+        box-shadow: 0 24px 44px rgba(15, 23, 42, 0.12);
+    }
+
+    .desktop-layout .sidebar .nav-link:hover i {
+        background: color-mix(in srgb, var(--primary-color) 28%, white 72%);
+        color: color-mix(in srgb, var(--primary-color) 90%, white 10%);
+        box-shadow: 0 16px 28px color-mix(in srgb, var(--primary-color) 28%, transparent);
+    }
+
+    .desktop-layout .sidebar .nav-link.active {
+        color: #ffffff !important;
+        background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 65%, #7b66ff 35%), color-mix(in srgb, var(--primary-color) 48%, #60a5fa 52%));
+        border-color: transparent;
+        box-shadow: 0 28px 48px color-mix(in srgb, var(--primary-color) 26%, transparent);
+    }
+
+    .desktop-layout .sidebar .nav-link.active i {
+        background: rgba(255, 255, 255, 0.2);
+        color: #ffffff;
+        box-shadow: none;
+    }
+
+    .desktop-layout .nav-item--home .nav-link {
+        background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 70%, #7b66ff 30%), color-mix(in srgb, var(--primary-color) 48%, #60a5fa 52%));
+        color: #ffffff !important;
+        border-color: transparent;
+        box-shadow: 0 26px 46px color-mix(in srgb, var(--primary-color) 28%, transparent);
+    }
+
+    .desktop-layout .nav-item--home .nav-link i {
+        background: rgba(255, 255, 255, 0.22);
+        color: #ffffff;
+    }
+
+    .desktop-layout .nav-submenu {
+        position: relative;
+        margin-left: 0.75rem;
+        padding-left: 1.75rem;
+        gap: 0.45rem;
+        border-left: 1px solid color-mix(in srgb, var(--primary-color) 16%, transparent);
+    }
+
+    .desktop-layout .nav-submenu::before {
+        content: "";
+        position: absolute;
+        left: -0.6rem;
+        top: 0.5rem;
+        bottom: 0.5rem;
+        width: 0.25rem;
+        border-radius: 999px;
+        background: linear-gradient(180deg, color-mix(in srgb, var(--primary-color) 32%, transparent), transparent);
+        opacity: 0.4;
+        pointer-events: none;
+    }
+
+    .desktop-layout .nav-submenu .submenu-link {
+        padding: 0.65rem 1rem;
+        border-radius: 1rem;
+        border: 1px solid transparent;
+        background: transparent;
+        color: color-mix(in srgb, var(--text-secondary) 78%, var(--primary-color) 22%) !important;
+    }
+
+    .desktop-layout .nav-submenu .submenu-link i {
+        width: 2.1rem;
+        height: 2.1rem;
+        border-radius: 0.85rem;
+        font-size: 0.95rem;
+        background: color-mix(in srgb, var(--primary-color) 10%, transparent);
+        color: color-mix(in srgb, var(--primary-color) 72%, #243b5d 28%);
+        box-shadow: none;
+    }
+
+    .desktop-layout .nav-submenu .submenu-link:hover {
+        transform: translateX(8px);
+        background: rgba(255, 255, 255, 0.9);
+        border-color: color-mix(in srgb, var(--primary-color) 22%, transparent);
+        box-shadow: 0 20px 38px rgba(15, 23, 42, 0.1);
+        color: color-mix(in srgb, var(--primary-color) 60%, #1f2238 40%) !important;
+    }
+
+    .desktop-layout .nav-submenu .submenu-link:hover i {
+        background: color-mix(in srgb, var(--primary-color) 28%, white 72%);
+        color: color-mix(in srgb, var(--primary-color) 92%, white 8%);
+        box-shadow: 0 12px 24px color-mix(in srgb, var(--primary-color) 24%, transparent);
+    }
+
+    .desktop-layout .nav-submenu .submenu-link.active {
+        background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 62%, #7b66ff 38%), color-mix(in srgb, var(--primary-color) 44%, #60a5fa 56%));
+        border-color: transparent;
+        box-shadow: 0 26px 44px color-mix(in srgb, var(--primary-color) 26%, transparent);
+        color: #ffffff !important;
+    }
+
+    .desktop-layout .nav-submenu .submenu-link.active i {
+        background: rgba(255, 255, 255, 0.2);
+        color: #ffffff;
     }
 
     .desktop-layout .nav-drawer__footer {


### PR DESCRIPTION
## Summary
- refresh the nav drawer header for tablet/desktop widths with a softer gradient brand block and updated logout styling
- restyle the desktop sidebar navigation into card-like menu and submenu items while keeping changes scoped to `@media (min-width: 768px)` so mobile remains unchanged

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cb371ae0f8832c852bd91710c7d346